### PR TITLE
Added export capabilities for lists, booleans and null SassTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,14 +9,21 @@ class SassVarsToJSON {
       case 'SassMap':
         return SassVarsToJSON.parseChunks(chunk.value)
 
+      case 'SassList':
+        return SassVarsToJSON.parseList(chunk)
+
       case 'SassColor':
-        return chunk.value.hex
+        return SassVarsToJSON.parseColor(chunk.value)
 
       case 'SassString':
         return chunk.value
 
       case 'SassNumber':
         return chunk.value + chunk.unit
+
+      case 'SassBoolean':
+      case 'SassNull':
+        return chunk.value
     }
   }
 
@@ -24,6 +31,27 @@ class SassVarsToJSON {
     return _.mapValues(chunks, (chunk, name) => {
       return SassVarsToJSON.parseTypeToValue(chunk)
     })
+  }
+
+  static parseColor (color) {
+    if (color.a < 1) {
+      return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`
+    }
+
+    return color.hex
+  }
+
+  static parseList (list) {
+    const values = list.value
+    let parsedString = ''
+
+    const separator = list.separator !== ' ' ? list.separator + ' ' : list.separator;
+
+    values.forEach((value, index) => {
+      parsedString += `${SassVarsToJSON.parseTypeToValue(value)}${index === values.length - 1 ? '' : separator}`
+    })
+
+    return parsedString
   }
 
   static extract (file) {

--- a/tests/example.test.js
+++ b/tests/example.test.js
@@ -20,6 +20,26 @@ test('vars.$toolbarHeight', t => {
   t.is(variables.$toolbarHeight, '60px')
 })
 
+test('vars.$toolbarFont', t => {
+  t.is(variables.$toolbarFont, 'Roboto-Slab, Times New Roman, serif')
+})
+
+test('vars.$toolbarBoxShadow', t => {
+  t.is(variables.$toolbarBoxShadow, '10px 10px 5px 0px rgba(0, 0, 0, 0.75)')
+})
+
+test('vars.$toolbarBgColor', t => {
+  t.is(variables.$toolbarBgColor, 'rgba(231, 231, 231, 0.5)')
+})
+
+test('vars.$toolbarIsFixed', t => {
+  t.is(variables.$toolbarIsFixed, true)
+})
+
+test('vars.$toolbarColor', t => {
+  t.is(variables.$toolbarColor, null)
+})
+
 test('vars.$palette.white', t => {
   t.is(variables.$palette.white, '#e7e7e7')
 })

--- a/tests/itworks.test.js
+++ b/tests/itworks.test.js
@@ -22,7 +22,7 @@ test('Returns an object', async t => {
 })
 
 test('Has the exact amount of exported variables', async t => {
-  t.is(_.size(variables), 4, 'Must have 4 variables only')
+  t.is(_.size(variables), 6, 'Must have 6 variables only')
 })
 
 test('Render single variables', async t => {
@@ -31,12 +31,14 @@ test('Render single variables', async t => {
 
 test('Render map objects', async t => {
   t.true(typeof variables.$color === 'object')
-  t.is(_.size(variables.$color), 12)
+  t.is(_.size(variables.$color), 13)
 })
 
 test('Render colors', async t => {
   t.is(variables.$color.green, '#27bab4')
   t.is(variables.$color.orange, '#ffcc00')
+
+  t.is(variables.$color['white-50opacity'], 'rgba(231, 231, 231, 0.5)')
 })
 
 test('Render numbers', async t => {
@@ -46,6 +48,19 @@ test('Render numbers', async t => {
 
 test('Render strings', async t => {
   t.is(variables.$theme['table-body-checkbox-border'], 'none')
+})
+
+test('Render boolean values', async t => {
+  t.is(variables.$useSass, true)
+  t.is(variables.$theme['headbar-is-fixed'], false)
+})
+
+test('Render null values', async t => {
+  t.is(variables.$nullVariable, null)
+})
+
+test('Render list values', async t => {
+  t.is(variables.$theme['navbar-border'], '1px solid rgba(231, 231, 231, 0.5)')
 })
 
 test('Render map-get\'s', async t => {

--- a/tests/scss/example.scss
+++ b/tests/scss/example.scss
@@ -1,4 +1,9 @@
 $toolbarHeight: 60px;
+$toolbarFont: "Roboto-Slab", "Times New Roman", serif;
+$toolbarBoxShadow: 10px 10px 5px 0px rgba(0, 0, 0, 0.75);
+$toolbarBgColor: rgba(#e7e7e7, .5);
+$toolbarIsFixed: true;
+$toolbarColor: null;
 $palette: (
   white: #e7e7e7,
   orange: #fc0

--- a/tests/scss/variables.scss
+++ b/tests/scss/variables.scss
@@ -1,4 +1,6 @@
 $single: "yeah";
+$useSass: true;
+$nullVariable: null;
 
 $color: (
   green: #27BAB4,
@@ -12,12 +14,14 @@ $color: (
   gray-light: #ccc,
   orange: #fc0,
   sand: #fef0c1,
-  white: #e7e7e7
+  white: #e7e7e7,
+  white-50opacity: rgba(#e7e7e7, .5)
 );
 
 $palette: (
   primary: map-get($color, green),
-  secondary: map-get($color, white)
+  secondary: map-get($color, white),
+  tertiary: map-get($color, white-50opacity)
 );
 
 $theme: (
@@ -25,6 +29,7 @@ $theme: (
   secondary: map-get($color, white),
   secondary-alt: map-get($color, white),
   navbar-background: map-get($color, black),
+  navbar-border: 1px solid map-get($palette, tertiary),
   navbar-button-background: transparent,
   navbar-button-background-over: transparent,
   navbar-button-background-active: transparent,
@@ -41,6 +46,7 @@ $theme: (
   headbar-background: map-get($palette, primary),
   nav-icon-color: map-get($color, white),
   headbar-height: 60px,
+  headbar-is-fixed: false,
   headbar-button-sep-color: map-get($color, real-black),
   headbar-button-color: map-get($palette, primary),
   loading-solid-background: map-get($color, black),


### PR DESCRIPTION
## Description 
As per [[REQUEST] Sass Vars to JSON - Does not seem to support Boolean and List type values](https://github.com/devtin/sass-vars-to-json/issues/1), adding export capabilities for:

- Lists, e.g: ```$font-family: "Times New Roman", Georgia, serif``` OR ```$box-shadow: 10px 10px 5px 0px rgba(0, 0, 0, 0.75)```. JSON key value exported as ```'$font-family': "Times New Roman, Georgia, serif'``` and ```'$box-shadow': '10px 10px 5px 0px rgba(0, 0, 0, 0.75)'``` respectively
- Booleans, e.g: ```$is-fixed: true```. JSON key value exported as ```'$is-fixed': true```
- Null Values, e.g. ```$font-family: null```. JSON key value exported as ```'$font-family': null```

Also changed the way how SassColour types are exported whereby:
- If there is an alpha (opacity) within the colour, colour exports as an ```rgba()``` NOT Hex

I have not triggered any release as of yet.

I'll leave the rest up to you.

Thanks.